### PR TITLE
prepare for docker

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "__infrastructure"]
+	path = __infrastructure
+	url = git@gitlab.com:nspgroup/products/ml-demos/infrastructure.git
+	branch = develop

--- a/app.py
+++ b/app.py
@@ -1,0 +1,14 @@
+import streamlit as st
+
+from app.st_auth import check_password # type: ignore
+from app.st_nsp import show_logo # type: ignore
+from app import app_name, app_executable # type: ignore
+
+#if not check_password():
+#    st.stop()
+
+# st.set_page_config(page_title=app_name, page_icon=":robot:")
+
+show_logo()
+
+app_executable()

--- a/nsp_chatbot_st.py
+++ b/nsp_chatbot_st.py
@@ -1,14 +1,1 @@
-import streamlit as st
-
-from app.st_auth import check_password # type: ignore
-from app.st_nsp import show_logo # type: ignore
-from app import app_name, app_executable # type: ignore
-
-#if not check_password():
-#    st.stop()
-
-# st.set_page_config(page_title=app_name, page_icon=":robot:")
-
-show_logo()
-
-app_executable()
+app.py


### PR DESCRIPTION
This PR prepares codebase so we can package it in a docker container.
Changes:

* entrypoint is `app.py`, legacy `st_main.py` is now a symlink to it
* add ml-demos/infrastructure repo git submodule so we can use an unified dockerfile